### PR TITLE
Extend individual options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ export class AppComponent {
 
 ```ts
 export interface NgDateRangePickerOptions {
-  theme: 'default' | 'green' | 'teal' | 'cyan' | 'grape' | 'red' | 'gray';
-  range: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly';
-  dayNames: string[];
-  presetNames: string[];
-  dateFormat: string;
-  outputFormat: string;
-  startOfWeek: number;
+  theme?: 'default' | 'green' | 'teal' | 'cyan' | 'grape' | 'red' | 'gray';
+  range?: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly';
+  dayNames?: string[];
+  presetNames?: string[];
+  dateFormat?: string;
+  outputFormat?: string;
+  startOfWeek?: number;
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "zone.js": "^0.7.7"
   },
   "dependencies": {
-    "date-fns": "^1.28.0",
-    "lodash": "^4.17.4"
+    "date-fns": "^1.28.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "zone.js": "^0.7.7"
   },
   "dependencies": {
-    "date-fns": "^1.28.0"
+    "date-fns": "^1.28.0",
+    "lodash": "^4.17.4"
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -22,7 +22,7 @@
                 <label class="label">Theme</label>
               </div>
               <span class="select">
-                <select [(ngModel)]="options.theme">
+                <select (change)="this.options.theme = $event.target.value">
                   <option>default</option>
                   <option>green</option>
                   <option>teal</option>

--- a/src/ng-daterangepicker/ng-daterangepicker.component.ts
+++ b/src/ng-daterangepicker/ng-daterangepicker.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, HostListener, ElementRef, forwardRef, Input, OnChanges, SimpleChange } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import * as dateFns from 'date-fns';
-import * as _ from 'lodash';
 
 export interface NgDateRangePickerOptions {
   theme?: 'default' | 'green' | 'teal' | 'cyan' | 'grape' | 'red' | 'gray';
@@ -90,8 +89,11 @@ export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit 
   ngOnInit() {
     this.opened = false;
     this.date = dateFns.startOfDay(new Date());
-    _.assignInWith(this.options || {}, this.defaultOptions, (objValue, srcValue) => {
-      return _.isUndefined(objValue) ? srcValue : objValue;
+    this.options = this.options || {};
+    Object.keys(this.defaultOptions).forEach((key) => {
+        if (!this.options.hasOwnProperty(key)) {
+            this.options[key] = this.defaultOptions[key];
+        }
     });
     this.initNames();
     this.selectRange(this.options.range);

--- a/src/ng-daterangepicker/ng-daterangepicker.component.ts
+++ b/src/ng-daterangepicker/ng-daterangepicker.component.ts
@@ -1,15 +1,16 @@
 import { Component, OnInit, HostListener, ElementRef, forwardRef, Input, OnChanges, SimpleChange } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import * as dateFns from 'date-fns';
+import * as _ from 'lodash';
 
 export interface NgDateRangePickerOptions {
-  theme: 'default' | 'green' | 'teal' | 'cyan' | 'grape' | 'red' | 'gray';
-  range: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly';
-  dayNames: string[];
-  presetNames: string[];
-  dateFormat: string;
-  outputFormat: string;
-  startOfWeek: number;
+  theme?: 'default' | 'green' | 'teal' | 'cyan' | 'grape' | 'red' | 'gray';
+  range?: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly';
+  dayNames?: string[];
+  presetNames?: string[];
+  dateFormat?: string;
+  outputFormat?: string;
+  startOfWeek?: number;
 }
 
 export interface IDay {
@@ -37,7 +38,7 @@ export let DATERANGEPICKER_VALUE_ACCESSOR: any = {
   styleUrls: ['ng-daterangepicker.sass'],
   providers: [ DATERANGEPICKER_VALUE_ACCESSOR ]
 })
-export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit, OnChanges {
+export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit {
   @Input() options: NgDateRangePickerOptions;
 
   modelValue: string;
@@ -56,7 +57,7 @@ export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit,
     dateFormat: 'yMd',
     outputFormat: 'DD/MM/YYYY',
     startOfWeek: 0
-  }
+  };
 
   private onTouchedCallback: () => void = () => { };
   private onChangeCallback: (_: any) => void = () => { };
@@ -89,13 +90,9 @@ export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit,
   ngOnInit() {
     this.opened = false;
     this.date = dateFns.startOfDay(new Date());
-    this.options = this.options || this.defaultOptions;
+    this.options = _.extend(this.options || {}, this.defaultOptions);
     this.initNames();
     this.selectRange(this.options.range);
-  }
-
-  ngOnChanges(changes: {[propName: string]: SimpleChange}) {
-    this.options = this.options || this.defaultOptions;
   }
 
   initNames(): void {

--- a/src/ng-daterangepicker/ng-daterangepicker.component.ts
+++ b/src/ng-daterangepicker/ng-daterangepicker.component.ts
@@ -90,7 +90,9 @@ export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit 
   ngOnInit() {
     this.opened = false;
     this.date = dateFns.startOfDay(new Date());
-    this.options = _.extend(this.options || {}, this.defaultOptions);
+    _.assignInWith(this.options || {}, this.defaultOptions, (objValue, srcValue) => {
+      return _.isUndefined(objValue) ? srcValue : objValue;
+    });
     this.initNames();
     this.selectRange(this.options.range);
   }

--- a/src/ng-daterangepicker/ng-daterangepicker.component.ts
+++ b/src/ng-daterangepicker/ng-daterangepicker.component.ts
@@ -10,6 +10,8 @@ export interface NgDateRangePickerOptions {
   dateFormat?: string;
   outputFormat?: string;
   startOfWeek?: number;
+  // needed for: Element implicitly has an 'any' type because type has no index signature
+  [key: string]: any;
 }
 
 export interface IDay {


### PR DESCRIPTION
Rather than replicating the entire options object, this PR allows the user to only extend those options he/she wishes too.

Changes moved into this branch hence why: https://github.com/jkuri/ng-daterangepicker/pull/27 is closed