### PR TITLE
outputFormat fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ export class AppComponent {
 	  range: 'tm',
 	  dayNames: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
 	  presetNames: ['This Month', 'Last Month', 'This Week', 'Last Week', 'This Year', 'Last Year', 'Start', 'End'],
-	  dateFormat: 'yMd',
 	  outputFormat: 'DD/MM/YYYY',
 	  startOfWeek: 1
 	};

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ export interface NgDateRangePickerOptions {
   range: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly';
   dayNames: string[];
   presetNames: string[];
-  dateFormat: string;
   outputFormat: string;
   startOfWeek: number;
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -15,7 +15,6 @@ export class AppComponent implements OnInit  {
       range: 'tm',
       dayNames: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
       presetNames: ['This Month', 'Last Month', 'This Week', 'Last Week', 'This Year', 'Last Year', 'Start', 'End'],
-      dateFormat: 'yMd',
       outputFormat: 'DD/MM/YYYY',
       startOfWeek: 0
     };

--- a/src/ng-daterangepicker/ng-daterangepicker.component.html
+++ b/src/ng-daterangepicker/ng-daterangepicker.component.html
@@ -9,7 +9,7 @@
 
   <div class="input-section" (click)="toggleCalendar($event, 'from')">
     <span class="label-txt">{{options.presetNames[6]}}</span>
-    <span class="value-txt">{{ dateFrom | date:options.dateFormat }}</span>
+    <span class="value-txt">{{ formatDate(dateFrom) }}</span>
     <span class="cal-icon">
       <svg width="94px" height="94px" viewBox="3 3 94 94" version="1.1">
         <g id="Group" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(3.000000, 3.000000)">
@@ -21,7 +21,7 @@
 
   <div class="input-section" (click)="toggleCalendar($event, 'to')">
     <span class="label-txt">{{options.presetNames[7]}}</span>
-    <span class="value-txt">{{ dateTo | date:options.dateFormat }}</span>
+    <span class="value-txt">{{ formatDate(dateTo) }}</span>
     <span class="cal-icon">
       <svg width="94px" height="94px" viewBox="3 3 94 94" version="1.1">
         <g id="Group" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(3.000000, 3.000000)">

--- a/src/ng-daterangepicker/ng-daterangepicker.component.ts
+++ b/src/ng-daterangepicker/ng-daterangepicker.component.ts
@@ -7,7 +7,6 @@ export interface NgDateRangePickerOptions {
   range: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly';
   dayNames: string[];
   presetNames: string[];
-  dateFormat: string;
   outputFormat: string;
   startOfWeek: number;
 }
@@ -53,7 +52,6 @@ export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit,
     range: 'tm',
     dayNames: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
     presetNames: ['This Month', 'Last Month', 'This Week', 'Last Week', 'This Year', 'Last Year', 'Start', 'End'],
-    dateFormat: 'yMd',
     outputFormat: 'DD/MM/YYYY',
     startOfWeek: 0
   }
@@ -143,7 +141,11 @@ export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit,
     }
 
     this.days = prevMonthDays.concat(days);
-    this.value = `${dateFns.format(this.dateFrom, this.options.outputFormat)}-${dateFns.format(this.dateTo, this.options.outputFormat)}`;
+    this.value = `${this.formatDate(this.dateFrom)}-${this.formatDate(this.dateTo)}`;
+  }
+
+  formatDate(value: Date) {
+    return dateFns.format(value, this.options.outputFormat);
   }
 
   toggleCalendar(e: MouseEvent, selection: 'from' | 'to'): void {


### PR DESCRIPTION
Changing `outputFormat` has no effect. For example the german format is "DD.MM.YYYY".
This PR fixes it and removes the unnecessary dateFormat property.