### PR TITLE
Detach Calendar Popup

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -17,7 +17,8 @@ export class AppComponent implements OnInit  {
       presetNames: ['This Month', 'Last Month', 'This Week', 'Last Week', 'This Year', 'Last Year', 'Start', 'End'],
       dateFormat: 'yMd',
       outputFormat: 'DD/MM/YYYY',
-      startOfWeek: 0
+      startOfWeek: 0,
+      container: 'app-root'
     };
   }
 }

--- a/src/ng-daterangepicker/index.ts
+++ b/src/ng-daterangepicker/index.ts
@@ -1,2 +1,3 @@
 export * from './ng-daterangepicker.component';
 export * from './ng-daterangepicker.module';
+export * from './shared/ng-daterangepicker-options';

--- a/src/ng-daterangepicker/ng-daterange-calendar/ng-daterange-calendar.component.html
+++ b/src/ng-daterangepicker/ng-daterange-calendar/ng-daterange-calendar.component.html
@@ -1,0 +1,54 @@
+<div *ngIf="opened" [ngClass]="getCSSClasses()">
+  <div class="calendar-container">
+    <div class="controls">
+      <span class="control-icon" (click)="prevMonth()">
+        <svg width="13px" height="20px" viewBox="0 44 13 20" version="1.1">
+          <path d="M11.7062895,64 C11.6273879,64 11.5477012,63.9744846 11.480576,63.921491 L0.139160349,54.9910879 C0.0551556781,54.9247477 0.00451734852,54.8250413 0.000199351429,54.7174839 C-0.00333355528,54.6107116 0.0402389608,54.5074722 0.119140544,54.4356364 L11.4605562,44.095211 C11.6093308,43.9589979 11.8401474,43.9707742 11.9751829,44.1187637 C12.1110036,44.2675384 12.1004048,44.4983549 11.9516302,44.6333905 L0.928176181,54.6841175 L11.9323955,63.3491601 C12.0905912,63.4735969 12.1176768,63.7028433 11.9928475,63.861039 C11.9206191,63.9521095 11.8138469,64 11.7062895,64 Z" id="Shape" stroke="none" fill="#000000" fill-rule="nonzero"></path>
+        </svg>
+      </span>
+      <span class="control-title">
+        {{ date | date:'MMMM y' }}
+      </span>
+      <span class="control-icon" (click)="nextMonth()">
+        <svg width="13px" height="20px" viewBox="21 44 13 20">
+          <path d="M32.7062895,64 C32.6273879,64 32.5477012,63.9744846 32.480576,63.921491 L21.1391603,54.9910879 C21.0551557,54.9247477 21.0045173,54.8250413 21.0001994,54.7174839 C20.9966664,54.6107116 21.040239,54.5074722 21.1191405,54.4356364 L32.4605562,44.095211 C32.6093308,43.9589979 32.8401474,43.9707742 32.9751829,44.1187637 C33.1110036,44.2675384 33.1004048,44.4983549 32.9516302,44.6333905 L21.9281762,54.6841175 L32.9323955,63.3491601 C33.0905912,63.4735969 33.1176768,63.7028433 32.9928475,63.861039 C32.9206191,63.9521095 32.8138469,64 32.7062895,64 Z" id="Shape" stroke="none" fill="#000000" fill-rule="nonzero" transform="translate(27.035642, 54.000000) scale(-1, 1) translate(-27.035642, -54.000000) "></path>
+        </svg>
+      </span>
+    </div>
+    <div class="day-names">
+      <span class="day-name" *ngFor="let name of dayNames">{{ name }}</span>
+    </div>
+    <div class="days">
+      <div class="day"
+            *ngFor="let d of days; let i = index;"
+            [ngClass]="{
+              'is-within-range': d.isWithinRange,
+              'is-from': d.from,
+              'is-to': d.to,
+              'is-first-weekday': d.weekday === 1 || d.firstMonthDay,
+              'is-last-weekday': d.weekday === 0 || d.lastMonthDay }"
+            (click)="selectDate($event, i)">
+        <span *ngIf="d.visible" class="day-num" [class.is-active]="d.from || d.to">{{ d.day }}</span>
+      </div>
+    </div>
+  </div>
+  <div class="side-container">
+    <div class="side-container-buttons">
+      <button type="button" class="side-button" (click)="selectRange('tm')" [class.is-active]="currentRange === 'tm'">{{options.presetNames[0]}}</button>
+      <button type="button" class="side-button" (click)="selectRange('lm')" [class.is-active]="currentRange === 'lm'">{{options.presetNames[1]}}</button>
+      <button type="button" class="side-button" (click)="selectRange('tw')" [class.is-active]="currentRange === 'tw'">{{options.presetNames[2]}}</button>
+      <button type="button" class="side-button" (click)="selectRange('lw')" [class.is-active]="currentRange === 'lw'">{{options.presetNames[3]}}</button>
+      <button type="button" class="side-button" (click)="selectRange('ty')" [class.is-active]="currentRange === 'ty'">{{options.presetNames[4]}}</button>
+      <button type="button" class="side-button" (click)="selectRange('ly')" [class.is-active]="currentRange === 'ly'">{{options.presetNames[5]}}</button>
+    </div>
+    <span class="close-icon" (click)="closeCalendar($event)">
+      <svg width="20px" height="20px" viewBox="47 44 20 20" version="1.1">
+        <g id="Group" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(48.000000, 44.000000)">
+          <path d="M19.6876399,20 C19.6047542,19.999927 19.52529,19.9669423 19.4667175,19.9082976 L0.0839056416,0.525743396 C-0.0308734765,0.402566324 -0.0274867013,0.210616527 0.0915663128,0.0915650956 C0.210619327,-0.0274863359 0.402571676,-0.030873066 0.525750385,0.0839045261 L19.9085623,19.4664587 C19.9978567,19.5558631 20.0245499,19.6902301 19.9762091,19.8069762 C19.9278683,19.9237223 19.8139998,19.9998889 19.6876399,20 Z" id="Shape" fill="#000000" fill-rule="nonzero"></path>
+          <path d="M0.312360116,20 C0.186000167,19.9998889 0.0721317315,19.9237223 0.0237909073,19.8069762 C-0.0245499168,19.6902301 0.0021432967,19.5558631 0.0914377445,19.4664587 L19.4742496,0.0839045261 C19.5974283,-0.030873066 19.7893807,-0.0274863359 19.9084337,0.0915650956 C20.0274867,0.210616527 20.0308735,0.402566324 19.9160944,0.525743396 L0.533282488,19.9082976 C0.474709982,19.9669423 0.395245751,19.999927 0.312360116,20 L0.312360116,20 Z" id="Shape" fill="#000000" fill-rule="nonzero"></path>
+        </g>
+      </svg>
+    </span>
+  </div>
+  <div style="clear: both;"></div>
+</div>

--- a/src/ng-daterangepicker/ng-daterange-calendar/ng-daterange-calendar.component.sass
+++ b/src/ng-daterangepicker/ng-daterange-calendar/ng-daterange-calendar.component.sass
@@ -1,0 +1,278 @@
+@charset 'utf8'
+
+@import '../../styles/colors.sass'
+
+=unselectable
+  -webkit-touch-callout: none
+  -webkit-user-select: none
+  -moz-user-select: none
+  -ms-user-select: none
+  user-select: none
+
+.calendar
+  +unselectable
+  width: 500px
+  border: 1px solid $blue
+  border-radius: 7px
+  background: $white
+  z-index: 100
+
+  &:after
+    content: ''
+    position: absolute
+    display: block
+    width: 30px
+    height: 30px
+    top: -16px
+    left: 65px
+    transform: rotate(45deg)
+    border-top: 1px solid $blue
+    border-left: 1px solid $blue
+    background: $white
+    transition: left 0.5s
+
+  &.is-opened
+    display: block
+
+  &.is-to
+
+    &:after
+      left: 215px
+
+  .calendar-container
+    display: inline-block
+    width: 340px
+    height: 100%
+    padding: 20px
+    border-right: 1px solid $border-light
+    float: left
+
+    .controls
+      width: 100%
+      height: 20px
+      display: flex
+      justify-content: space-between
+      align-items: center
+
+      .control-icon
+        display: block
+        width: 12px
+        height: 20px
+        cursor: pointer
+
+      .control-title
+        font-size: 17px
+        color: $text
+
+    .day-names
+      display: inline-block
+      width: 300px
+      margin-top: 30px
+      margin-bottom: 20px
+
+      .day-name
+        width: calc(300px / 7)
+        font-size: 13px
+        color: $grey
+        display: block
+        float: left
+        text-align: center
+        font-weight: bold
+
+    .days
+      display: inline-block
+      width: 300px
+
+      .day
+        width: calc(300px / 7)
+        font-size: 13px
+        color: $grey
+        display: block
+        float: left
+        text-align: center
+        margin-bottom: 15px
+        cursor: pointer
+        font-weight: bold
+
+        &.is-within-range
+          background: $blue-light
+          color: $dark
+
+        &.is-from, &.is-first-weekday
+          border-top-left-radius: 50%
+          border-bottom-left-radius: 50%
+
+        &.is-to, &.is-last-weekday
+          border-top-right-radius: 50%
+          border-bottom-right-radius: 50%
+
+        .day-num
+          display: flex
+          justify-content: center
+          align-items: center
+          float: left
+          width: calc(300px / 7)
+          height: 100%
+          border-radius: 50%
+          padding: 10px 15px
+
+          &:hover, &.is-active
+            background: $blue
+            color: $white
+
+  .side-container
+    width: 158px
+    min-height: 390px
+    padding: 10px
+    display: flex
+    align-items: center
+    position: relative
+
+    .side-container-buttons
+      width: 138px
+
+      .side-button
+        background: $white
+        border-radius: 15px
+        border: 1px solid $blue
+        height: 30px
+        width: 138px
+        display: block
+        text-align: center
+        outline: none
+        margin-bottom: 15px
+        color: $text-button
+        font-size: 13px
+        cursor: pointer
+
+        &:hover, &.is-active
+          background: $blue
+          color: $white
+
+    .close-icon
+      position: absolute
+      width: 20px
+      height: 20px
+      top: 20px
+      right: 15px
+      cursor: pointer
+
+  &.theme-green
+    border-color: $green
+    &:after
+      border-top-color: $green
+      border-left-color: $green
+    .calendar-container
+      .days
+        .day
+          &.is-within-range
+            background: lighten($green, 20)
+          .day-num
+            &:hover, &.is-active
+              background: $green
+    .side-container
+      .side-container-buttons
+        .side-button
+          border-color: $green
+          &:hover, &.is-active
+            background: $green
+
+  &.theme-teal
+    border-color: $teal
+    &:after
+      border-top-color: $teal
+      border-left-color: $teal
+    .calendar-container
+      .days
+        .day
+          &.is-within-range
+            background: lighten($teal, 20)
+          .day-num
+            &:hover, &.is-active
+              background: $teal
+    .side-container
+      .side-container-buttons
+        .side-button
+          border-color: $teal
+          &:hover, &.is-active
+            background: $teal
+
+  &.theme-cyan
+    border-color: $cyan
+    &:after
+      border-top-color: $cyan
+      border-left-color: $cyan
+    .calendar-container
+      .days
+        .day
+          &.is-within-range
+            background: lighten($cyan, 20)
+          .day-num
+            &:hover, &.is-active
+              background: $cyan
+    .side-container
+      .side-container-buttons
+        .side-button
+          border-color: $cyan
+          &:hover, &.is-active
+            background: $cyan
+
+  &.theme-grape
+    border-color: $grape
+    &:after
+      border-top-color: $grape
+      border-left-color: $grape
+    .calendar-container
+      .days
+        .day
+          &.is-within-range
+            background: lighten($grape, 20)
+          .day-num
+            &:hover, &.is-active
+              background: $grape
+    .side-container
+      .side-container-buttons
+        .side-button
+          border-color: $grape
+          &:hover, &.is-active
+            background: $grape
+
+  &.theme-red
+    border-color: $red
+    &:after
+      border-top-color: $red
+      border-left-color: $red
+    .calendar-container
+      .days
+        .day
+          &.is-within-range
+            background: lighten($red, 20)
+          .day-num
+            &:hover, &.is-active
+              background: $red
+    .side-container
+      .side-container-buttons
+        .side-button
+          border-color: $red
+          &:hover, &.is-active
+            background: $red
+
+  &.theme-gray
+    border-color: $gray
+    &:after
+      border-top-color: $gray
+      border-left-color: $gray
+    .calendar-container
+      .days
+        .day
+          &.is-within-range
+            background: lighten($gray, 20)
+          .day-num
+            &:hover, &.is-active
+              background: $gray
+    .side-container
+      .side-container-buttons
+        .side-button
+          border-color: $gray
+          &:hover, &.is-active
+            background: $gray

--- a/src/ng-daterangepicker/ng-daterange-calendar/ng-daterange-calendar.component.ts
+++ b/src/ng-daterangepicker/ng-daterange-calendar/ng-daterange-calendar.component.ts
@@ -1,0 +1,185 @@
+import { DateObj, NgDateRangePickerHelper } from '../shared/ng-daterangerpicker.helper';
+import { Component, ElementRef, EventEmitter, Injectable, Input, OnInit, Output } from '@angular/core';
+import { NgDateRangePickerOptions } from '../shared/ng-daterangepicker-options';
+import * as dateFns from 'date-fns';
+
+export interface IDay {
+  date: Date;
+  day: number;
+  weekday: number;
+  today: boolean;
+  firstMonthDay: boolean;
+  lastMonthDay: boolean;
+  visible: boolean;
+  from: boolean;
+  to: boolean;
+  isWithinRange: boolean;
+}
+
+@Component({
+    selector: 'ng-daterange-calendar',
+    templateUrl: 'ng-daterange-calendar.component.html',
+    styleUrls: ['ng-daterange-calendar.component.sass']
+})
+@Injectable()
+export class NgDateRangeCalendarComponent implements OnInit {
+    @Input() options: NgDateRangePickerOptions;
+    @Input() target: Element | false;
+    @Output() onDateFrom: EventEmitter<Date> = new EventEmitter<Date>();
+    @Output() onDateTo: EventEmitter<Date> = new EventEmitter<Date>();
+    @Output() onValueChange: EventEmitter<string> = new EventEmitter<string>();
+    @Input() opened: false | 'from' | 'to';
+    @Input() currentRange: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly';
+
+    _dateFrom: Date;
+    get dateFrom(): Date {
+        return this._dateFrom;
+    };
+
+    set dateFrom(value: Date) {
+        this._dateFrom = value;
+        this.onDateFrom.emit(this.dateFrom);
+    }
+
+    _dateTo: Date;
+    get dateTo(): Date {
+        return this._dateTo;
+    };
+
+    set dateTo(value: Date) {
+        this._dateTo = value;
+        this.onDateTo.emit(this.dateTo);
+    }
+
+    private coords: ClientRect;
+    date: Date;
+    dayNames: string[];
+    days: IDay[];
+
+    constructor(public element: ElementRef,
+                private helper: NgDateRangePickerHelper) { }
+
+    ngOnInit(): void {
+        this.date = dateFns.startOfDay(new Date());
+        this.currentRange = this.options.range;
+        this.initNames();
+        this.showAt();
+        this.generateCalendar();
+    }
+
+    initNames(): void {
+        this.dayNames = this.options.dayNames;
+    }
+
+    showAt(): void {
+        if (this.target) {
+            this.coords = this.target.getBoundingClientRect();
+        } else {
+            this.coords = {
+                top: 0,
+                left: 0,
+                bottom: 0,
+                right: 0
+            } as ClientRect;
+        }
+        let el: HTMLElement = this.element.nativeElement;
+        el.style.top = (this.coords.bottom + 75) + 'px';
+        el.style.left = this.coords.left + 'px';
+        el.style.position = 'absolute';
+    }
+
+    generateCalendar(): void {
+        this.days = [];
+        let start: Date = dateFns.startOfMonth(this.date);
+        let end: Date = dateFns.endOfMonth(this.date);
+
+        let days: IDay[] = dateFns.eachDay(start, end).map(d => {
+            return {
+                date: d,
+                day: dateFns.getDate(d),
+                weekday: dateFns.getDay(d),
+                today: dateFns.isToday(d),
+                firstMonthDay: dateFns.isFirstDayOfMonth(d),
+                lastMonthDay: dateFns.isLastDayOfMonth(d),
+                visible: true,
+                from: dateFns.isSameDay(this.dateFrom, d),
+                to: dateFns.isSameDay(this.dateTo, d),
+                isWithinRange: dateFns.isWithinRange(d, this.dateFrom, this.dateTo)
+            };
+        });
+
+        let prevMonthDayNum = dateFns.getDay(start) - 1;
+        let prevMonthDays: IDay[] = [];
+        if (prevMonthDayNum > 0) {
+            prevMonthDays = Array.from(Array(prevMonthDayNum).keys()).map(i => {
+                let d = dateFns.subDays(start, prevMonthDayNum - i);
+                return {
+                    date: d,
+                    day: dateFns.getDate(d),
+                    weekday: dateFns.getDay(d),
+                    firstMonthDay: dateFns.isFirstDayOfMonth(d),
+                    lastMonthDay: dateFns.isLastDayOfMonth(d),
+                    today: false,
+                    visible: false,
+                    from: false,
+                    to: false,
+                    isWithinRange: false
+                };
+            });
+        }
+
+        this.days = prevMonthDays.concat(days);
+    }
+
+    selectDate(e: MouseEvent, index: number): void {
+        e.preventDefault();
+        let selectedDate: Date = this.days[index].date;
+        if ((this.opened === 'from' && dateFns.isAfter(selectedDate, this.dateTo)) ||
+            (this.opened === 'to' && dateFns.isBefore(selectedDate, this.dateFrom))) {
+            return;
+        }
+
+        if (this.opened === 'from') {
+            this.dateFrom = selectedDate;
+            this.opened = 'to';
+        } else if (this.opened === 'to') {
+            this.dateTo = selectedDate;
+            this.opened = 'from';
+        }
+
+        this.generateCalendar();
+        this.emitValue();
+    }
+
+    prevMonth(): void {
+        this.date = dateFns.subMonths(this.date, 1);
+        this.generateCalendar();
+    }
+
+    nextMonth(): void {
+        this.date = dateFns.addMonths(this.date, 1);
+        this.generateCalendar();
+    }
+
+    selectRange(range: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly'): void {
+        this.currentRange = range;
+        let dates: DateObj = this.helper.selectRange(this.options, range);
+        this.dateFrom = dates.dateFrom;
+        this.dateTo = dates.dateTo;
+        this.generateCalendar();
+        this.emitValue();
+    }
+
+    closeCalendar(e: MouseEvent): void {
+        this.opened = false;
+    }
+
+    emitValue(): void {
+        this.onValueChange
+            .emit(`${dateFns.format(this.dateFrom, this.options.outputFormat)}-${dateFns.format(this.dateTo, this.options.outputFormat)}`);
+    }
+
+    getCSSClasses(): string {
+        return `calendar theme-${this.options.theme}${!!this.opened ? ' is-opened' : ''}${this.opened === 'to' ? ' is-to' : ''}`;
+    }
+}

--- a/src/ng-daterangepicker/ng-daterangepicker.component.html
+++ b/src/ng-daterangepicker/ng-daterangepicker.component.html
@@ -1,11 +1,4 @@
-<div class="ng-daterangepicker"
-     [ngClass]="{ 'is-active': !!opened,
-                  'theme-green': options.theme === 'green',
-                  'theme-teal': options.theme === 'teal',
-                  'theme-cyan': options.theme === 'cyan',
-                  'theme-grape': options.theme === 'grape',
-                  'theme-red': options.theme === 'red',
-                  'theme-gray': options.theme === 'gray' }">
+<div [className]="getCSSClasses()">
 
   <div class="input-section" (click)="toggleCalendar($event, 'from')">
     <span class="label-txt">{{options.presetNames[6]}}</span>
@@ -29,59 +22,6 @@
         </g>
       </svg>
     </span>
-  </div>
-
-  <div class="calendar" [ngClass]="{ 'is-opened': !!opened, 'is-to': opened === 'to' }">
-    <div class="calendar-container">
-      <div class="controls">
-        <span class="control-icon" (click)="prevMonth()">
-          <svg width="13px" height="20px" viewBox="0 44 13 20" version="1.1">
-            <path d="M11.7062895,64 C11.6273879,64 11.5477012,63.9744846 11.480576,63.921491 L0.139160349,54.9910879 C0.0551556781,54.9247477 0.00451734852,54.8250413 0.000199351429,54.7174839 C-0.00333355528,54.6107116 0.0402389608,54.5074722 0.119140544,54.4356364 L11.4605562,44.095211 C11.6093308,43.9589979 11.8401474,43.9707742 11.9751829,44.1187637 C12.1110036,44.2675384 12.1004048,44.4983549 11.9516302,44.6333905 L0.928176181,54.6841175 L11.9323955,63.3491601 C12.0905912,63.4735969 12.1176768,63.7028433 11.9928475,63.861039 C11.9206191,63.9521095 11.8138469,64 11.7062895,64 Z" id="Shape" stroke="none" fill="#000000" fill-rule="nonzero"></path>
-          </svg>
-        </span>
-        <span class="control-title">
-          {{ date | date:'MMMM y' }}
-        </span>
-        <span class="control-icon" (click)="nextMonth()">
-          <svg width="13px" height="20px" viewBox="21 44 13 20">
-            <path d="M32.7062895,64 C32.6273879,64 32.5477012,63.9744846 32.480576,63.921491 L21.1391603,54.9910879 C21.0551557,54.9247477 21.0045173,54.8250413 21.0001994,54.7174839 C20.9966664,54.6107116 21.040239,54.5074722 21.1191405,54.4356364 L32.4605562,44.095211 C32.6093308,43.9589979 32.8401474,43.9707742 32.9751829,44.1187637 C33.1110036,44.2675384 33.1004048,44.4983549 32.9516302,44.6333905 L21.9281762,54.6841175 L32.9323955,63.3491601 C33.0905912,63.4735969 33.1176768,63.7028433 32.9928475,63.861039 C32.9206191,63.9521095 32.8138469,64 32.7062895,64 Z" id="Shape" stroke="none" fill="#000000" fill-rule="nonzero" transform="translate(27.035642, 54.000000) scale(-1, 1) translate(-27.035642, -54.000000) "></path>
-          </svg>
-        </span>
-      </div>
-      <div class="day-names">
-        <span class="day-name" *ngFor="let name of dayNames">{{ name }}</span>
-      </div>
-      <div class="days">
-        <div class="day"
-             *ngFor="let d of days; let i = index;"
-             [ngClass]="{
-               'is-within-range': d.isWithinRange,
-               'is-from': d.from,
-               'is-to': d.to,
-               'is-first-weekday': d.weekday === 1 || d.firstMonthDay,
-               'is-last-weekday': d.weekday === 0 || d.lastMonthDay }"
-             (click)="selectDate($event, i)">
-          <span *ngIf="d.visible" class="day-num" [class.is-active]="d.from || d.to">{{ d.day }}</span>
-        </div>
-      </div>
-    </div>
-    <div class="side-container">
-      <div class="side-container-buttons">
-        <button type="button" class="side-button" (click)="selectRange('tm')" [class.is-active]="range === 'tm'">{{options.presetNames[0]}}</button>
-        <button type="button" class="side-button" (click)="selectRange('lm')" [class.is-active]="range === 'lm'">{{options.presetNames[1]}}</button>
-        <button type="button" class="side-button" (click)="selectRange('tw')" [class.is-active]="range === 'tw'">{{options.presetNames[2]}}</button>
-        <button type="button" class="side-button" (click)="selectRange('lw')" [class.is-active]="range === 'lw'">{{options.presetNames[3]}}</button>
-        <button type="button" class="side-button" (click)="selectRange('ty')" [class.is-active]="range === 'ty'">{{options.presetNames[4]}}</button>
-        <button type="button" class="side-button" (click)="selectRange('ly')" [class.is-active]="range === 'ly'">{{options.presetNames[5]}}</button>
-      </div>
-      <span class="close-icon" (click)="closeCalendar($event)">
-        <svg width="20px" height="20px" viewBox="47 44 20 20" version="1.1">
-          <g id="Group" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(48.000000, 44.000000)">
-            <path d="M19.6876399,20 C19.6047542,19.999927 19.52529,19.9669423 19.4667175,19.9082976 L0.0839056416,0.525743396 C-0.0308734765,0.402566324 -0.0274867013,0.210616527 0.0915663128,0.0915650956 C0.210619327,-0.0274863359 0.402571676,-0.030873066 0.525750385,0.0839045261 L19.9085623,19.4664587 C19.9978567,19.5558631 20.0245499,19.6902301 19.9762091,19.8069762 C19.9278683,19.9237223 19.8139998,19.9998889 19.6876399,20 Z" id="Shape" fill="#000000" fill-rule="nonzero"></path>
-            <path d="M0.312360116,20 C0.186000167,19.9998889 0.0721317315,19.9237223 0.0237909073,19.8069762 C-0.0245499168,19.6902301 0.0021432967,19.5558631 0.0914377445,19.4664587 L19.4742496,0.0839045261 C19.5974283,-0.030873066 19.7893807,-0.0274863359 19.9084337,0.0915650956 C20.0274867,0.210616527 20.0308735,0.402566324 19.9160944,0.525743396 L0.533282488,19.9082976 C0.474709982,19.9669423 0.395245751,19.999927 0.312360116,20 L0.312360116,20 Z" id="Shape" fill="#000000" fill-rule="nonzero"></path>
-          </g>
-        </svg>
-      </span>
-    </div>
-  </div>
+  </div>  
+  <div #defaultContainer></div>
 </div>

--- a/src/ng-daterangepicker/ng-daterangepicker.component.ts
+++ b/src/ng-daterangepicker/ng-daterangepicker.component.ts
@@ -164,7 +164,7 @@ export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit,
   handleBlurClick(e: MouseEvent) {
     let target = e.srcElement || e.target;
     if (!this.elementRef.nativeElement.contains(e.target)
-      && (this.calendarComponentRef.instance && !this.calendarComponentRef.instance.element.nativeElement.contains(e.target))
+      && (this.calendarComponentRef && !this.calendarComponentRef.instance.element.nativeElement.contains(e.target))
       && !(<Element>target).classList.contains('day-num')) {
       this.opened = false;
     }

--- a/src/ng-daterangepicker/ng-daterangepicker.component.ts
+++ b/src/ng-daterangepicker/ng-daterangepicker.component.ts
@@ -164,7 +164,7 @@ export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit,
   handleBlurClick(e: MouseEvent) {
     let target = e.srcElement || e.target;
     if (!this.elementRef.nativeElement.contains(e.target)
-      && !this.calendarComponentRef.instance.element.nativeElement.contains(e.target)
+      && (this.calendarComponentRef.instance && !this.calendarComponentRef.instance.element.nativeElement.contains(e.target))
       && !(<Element>target).classList.contains('day-num')) {
       this.opened = false;
     }

--- a/src/ng-daterangepicker/ng-daterangepicker.component.ts
+++ b/src/ng-daterangepicker/ng-daterangepicker.component.ts
@@ -1,29 +1,29 @@
-import { Component, OnInit, HostListener, ElementRef, forwardRef, Input, OnChanges, SimpleChange } from '@angular/core';
+import { DateObj, NgDateRangePickerHelper } from './shared/ng-daterangerpicker.helper';
+import {
+    NgDateRangeCalendarComponent
+} from './ng-daterange-calendar/ng-daterange-calendar.component';
+import {
+    ApplicationRef,
+    Component,
+    ComponentFactory,
+    ComponentFactoryResolver,
+    ComponentRef,
+    ElementRef,
+    forwardRef,
+    HostListener,
+    Injector,
+    Input,
+    OnChanges,
+    OnInit,
+    Renderer,
+    SimpleChange,
+    Type,
+    ViewChild,
+    ViewContainerRef
+} from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+import { NgDateRangePickerOptions } from './shared/ng-daterangepicker-options';
 import * as dateFns from 'date-fns';
-
-export interface NgDateRangePickerOptions {
-  theme: 'default' | 'green' | 'teal' | 'cyan' | 'grape' | 'red' | 'gray';
-  range: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly';
-  dayNames: string[];
-  presetNames: string[];
-  dateFormat: string;
-  outputFormat: string;
-  startOfWeek: number;
-}
-
-export interface IDay {
-  date: Date;
-  day: number;
-  weekday: number;
-  today: boolean;
-  firstMonthDay: boolean;
-  lastMonthDay: boolean;
-  visible: boolean;
-  from: boolean;
-  to: boolean;
-  isWithinRange: boolean;
-}
 
 export let DATERANGEPICKER_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -39,15 +39,25 @@ export let DATERANGEPICKER_VALUE_ACCESSOR: any = {
 })
 export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit, OnChanges {
   @Input() options: NgDateRangePickerOptions;
+  @Input() container: string;
+  @ViewChild('defaultContainer')
+  public defaultContainer: ElementRef;
 
+  created: boolean;
+  calendarComponentRef: ComponentRef<NgDateRangeCalendarComponent>;
   modelValue: string;
-  opened: false | 'from' | 'to';
-  date: Date;
+  _opened: false | 'from' | 'to' = false;
+  get opened(): false | 'from' | 'to' {
+    return this._opened;
+  };
+  set opened(value: false | 'from' | 'to') {
+    this._opened = value;
+    if (this.calendarComponentRef && this.calendarComponentRef.instance) {
+      this.calendarComponentRef.instance.opened = this.opened;
+    }
+  };
   dateFrom: Date;
   dateTo: Date;
-  dayNames: string[];
-  days: IDay[];
-  range: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly';
   defaultOptions: NgDateRangePickerOptions = {
     theme: 'default',
     range: 'tm',
@@ -55,13 +65,21 @@ export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit,
     presetNames: ['This Month', 'Last Month', 'This Week', 'Last Week', 'This Year', 'Last Year', 'Start', 'End'],
     dateFormat: 'yMd',
     outputFormat: 'DD/MM/YYYY',
-    startOfWeek: 0
+    startOfWeek: 0,
+    container: false
   }
 
   private onTouchedCallback: () => void = () => { };
   private onChangeCallback: (_: any) => void = () => { };
 
-  constructor(private elementRef: ElementRef) { }
+  constructor(private elementRef: ElementRef,
+              private renderer: Renderer,
+              private injector: Injector,
+              private viewContainerRef: ViewContainerRef,
+              private applicationRef: ApplicationRef,
+              private componentFactoryResolver: ComponentFactoryResolver,
+              private helper: NgDateRangePickerHelper) {
+  }
 
   get value(): string {
     return this.modelValue;
@@ -87,147 +105,67 @@ export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit,
   }
 
   ngOnInit() {
-    this.opened = false;
-    this.date = dateFns.startOfDay(new Date());
     this.options = this.options || this.defaultOptions;
-    this.initNames();
-    this.selectRange(this.options.range);
+    let dates: DateObj = this.helper.selectRange(this.options);
+    this.dateFrom = dates.dateFrom;
+    this.dateTo = dates.dateTo;
   }
 
   ngOnChanges(changes: {[propName: string]: SimpleChange}) {
     this.options = this.options || this.defaultOptions;
   }
 
-  initNames(): void {
-    this.dayNames = this.options.dayNames;
-  }
-
-  generateCalendar(): void {
-    this.days = [];
-    let start: Date = dateFns.startOfMonth(this.date);
-    let end: Date = dateFns.endOfMonth(this.date);
-
-    let days: IDay[] = dateFns.eachDay(start, end).map(d => {
-      return {
-        date: d,
-        day: dateFns.getDate(d),
-        weekday: dateFns.getDay(d),
-        today: dateFns.isToday(d),
-        firstMonthDay: dateFns.isFirstDayOfMonth(d),
-        lastMonthDay: dateFns.isLastDayOfMonth(d),
-        visible: true,
-        from: dateFns.isSameDay(this.dateFrom, d),
-        to: dateFns.isSameDay(this.dateTo, d),
-        isWithinRange: dateFns.isWithinRange(d, this.dateFrom, this.dateTo)
-      };
-    });
-
-    let prevMonthDayNum = dateFns.getDay(start) - 1;
-    let prevMonthDays: IDay[] = [];
-    if (prevMonthDayNum > 0) {
-      prevMonthDays = Array.from(Array(prevMonthDayNum).keys()).map(i => {
-        let d = dateFns.subDays(start, prevMonthDayNum - i);
-        return {
-          date: d,
-          day: dateFns.getDate(d),
-          weekday: dateFns.getDay(d),
-          firstMonthDay: dateFns.isFirstDayOfMonth(d),
-          lastMonthDay: dateFns.isLastDayOfMonth(d),
-          today: false,
-          visible: false,
-          from: false,
-          to: false,
-          isWithinRange: false
-        };
-      });
-    }
-
-    this.days = prevMonthDays.concat(days);
-    this.value = `${dateFns.format(this.dateFrom, this.options.outputFormat)}-${dateFns.format(this.dateTo, this.options.outputFormat)}`;
-  }
-
   toggleCalendar(e: MouseEvent, selection: 'from' | 'to'): void {
+    if (!this.created) {
+      this.createCalendar();
+      this.created = true;
+    }
     if (this.opened && this.opened !== selection) {
       this.opened = selection;
+      this.calendarComponentRef.instance.opened = this.opened;
     } else {
       this.opened = this.opened ? false : selection;
+      this.calendarComponentRef.instance.opened = this.opened;
     }
   }
 
-  closeCalendar(e: MouseEvent): void {
-    this.opened = false;
+  createCalendar(): void {
+    this.calendarComponentRef = this.componentFactoryResolver.resolveComponentFactory(NgDateRangeCalendarComponent).create(this.injector);
+    this.initCalendar();
+    this.applicationRef.attachView(this.calendarComponentRef.hostView);
+    let container: HTMLElement = this.options.container ?
+      document.querySelector(this.options.container) :
+      this.defaultContainer.nativeElement;
+    container.appendChild(this.calendarComponentRef.location.nativeElement);
   }
 
-  selectDate(e: MouseEvent, index: number): void {
-    e.preventDefault();
-    let selectedDate: Date = this.days[index].date;
-    if ((this.opened === 'from' && dateFns.isAfter(selectedDate, this.dateTo)) ||
-      (this.opened === 'to' && dateFns.isBefore(selectedDate, this.dateFrom))) {
-      return;
-    }
-
-    if (this.opened === 'from') {
-      this.dateFrom = selectedDate;
-      this.opened = 'to';
-    } else if (this.opened === 'to') {
-      this.dateTo = selectedDate;
-      this.opened = 'from';
-    }
-
-    this.generateCalendar();
+  initCalendar(): void {
+    this.calendarComponentRef.instance.options = this.options;
+    this.calendarComponentRef.instance.dateFrom = this.dateFrom;
+    this.calendarComponentRef.instance.dateTo = this.dateTo;
+    this.calendarComponentRef.instance.onDateFrom.subscribe((val: Date) => {
+        this.dateFrom = val;
+    });
+    this.calendarComponentRef.instance.onDateTo.subscribe((val: Date) => {
+        this.dateTo = val;
+    });
+    this.calendarComponentRef.instance.opened = this.opened;
+    this.calendarComponentRef.instance.onValueChange.subscribe((val: string) => {
+      this.value = val;
+    });
+    this.calendarComponentRef.instance.target = this.options.container ? this.defaultContainer.nativeElement : false;
   }
 
-  prevMonth(): void {
-    this.date = dateFns.subMonths(this.date, 1);
-    this.generateCalendar();
-  }
-
-  nextMonth(): void {
-    this.date = dateFns.addMonths(this.date, 1);
-    this.generateCalendar();
-  }
-
-  selectRange(range: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly'): void {
-    let today = dateFns.startOfDay(new Date());
-
-    switch (range) {
-      case 'tm':
-        this.dateFrom = dateFns.startOfMonth(today);
-        this.dateTo = dateFns.endOfMonth(today);
-        break;
-      case 'lm':
-        today = dateFns.subMonths(today, 1);
-        this.dateFrom = dateFns.startOfMonth(today);
-        this.dateTo = dateFns.endOfMonth(today);
-        break;
-      case 'lw':
-        today = dateFns.subWeeks(today, 1);
-        this.dateFrom = dateFns.startOfWeek(today, {weekStartsOn: this.options.startOfWeek});
-        this.dateTo = dateFns.endOfWeek(today, {weekStartsOn: this.options.startOfWeek});
-        break;
-      case 'tw':
-        this.dateFrom = dateFns.startOfWeek(today, {weekStartsOn: this.options.startOfWeek});
-        this.dateTo = dateFns.endOfWeek(today, {weekStartsOn: this.options.startOfWeek});
-        break;
-      case 'ty':
-        this.dateFrom = dateFns.startOfYear(today);
-        this.dateTo = dateFns.endOfYear(today);
-        break;
-      case 'ly':
-        today = dateFns.subYears(today, 1);
-        this.dateFrom = dateFns.startOfYear(today);
-        this.dateTo = dateFns.endOfYear(today);
-        break;
-    }
-
-    this.range = range;
-    this.generateCalendar();
+  getCSSClasses(): string {
+    return `ng-daterangepicker theme-${this.options.theme}${!!this.opened ? ' is-active' : ''}`;
   }
 
   @HostListener('document:click', ['$event'])
   handleBlurClick(e: MouseEvent) {
     let target = e.srcElement || e.target;
-    if (!this.elementRef.nativeElement.contains(e.target) && !(<Element>target).classList.contains('day-num')) {
+    if (!this.elementRef.nativeElement.contains(e.target)
+      && !this.calendarComponentRef.instance.element.nativeElement.contains(e.target)
+      && !(<Element>target).classList.contains('day-num')) {
       this.opened = false;
     }
   }

--- a/src/ng-daterangepicker/ng-daterangepicker.module.ts
+++ b/src/ng-daterangepicker/ng-daterangepicker.module.ts
@@ -1,11 +1,17 @@
+import { NgDateRangePickerHelper } from './shared/ng-daterangerpicker.helper';
+import {
+    NgDateRangeCalendarComponent
+} from './ng-daterange-calendar/ng-daterange-calendar.component';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgDateRangePickerComponent } from './ng-daterangepicker.component';
 
 @NgModule({
-  declarations: [ NgDateRangePickerComponent ],
+  entryComponents: [ NgDateRangeCalendarComponent],
+  declarations: [ NgDateRangePickerComponent, NgDateRangeCalendarComponent ],
   imports: [ CommonModule, FormsModule ],
-  exports: [ NgDateRangePickerComponent, CommonModule, FormsModule ]
+  exports: [ NgDateRangePickerComponent, CommonModule, FormsModule ],
+  providers: [ NgDateRangePickerHelper ]
 })
 export class NgDateRangePickerModule { }

--- a/src/ng-daterangepicker/ng-daterangepicker.sass
+++ b/src/ng-daterangepicker/ng-daterangepicker.sass
@@ -60,187 +60,16 @@
         path
           fill: $blue-icon
 
-  .calendar
-    +unselectable
-    width: 500px
-    border: 1px solid $blue
-    border-radius: 7px
-    background: $white
-    position: absolute
-    top: 75px
-    left: 0
-    z-index: 100
-    display: none
-
-    &:after
-      content: ''
-      position: absolute
-      display: block
-      width: 30px
-      height: 30px
-      top: -16px
-      left: 65px
-      transform: rotate(45deg)
-      border-top: 1px solid $blue
-      border-left: 1px solid $blue
-      background: $white
-      transition: left 0.5s
-
-    &.is-opened
-      display: block
-
-    &.is-to
-
-      &:after
-        left: 215px
-
-    .calendar-container
-      display: inline-block
-      width: 340px
-      height: 100%
-      padding: 20px
-      border-right: 1px solid $border-light
-      float: left
-
-      .controls
-        width: 100%
-        height: 20px
-        display: flex
-        justify-content: space-between
-        align-items: center
-
-        .control-icon
-          display: block
-          width: 12px
-          height: 20px
-          cursor: pointer
-
-        .control-title
-          font-size: 17px
-          color: $text
-
-      .day-names
-        display: inline-block
-        width: 300px
-        margin-top: 30px
-        margin-bottom: 20px
-
-        .day-name
-          width: calc(300px / 7)
-          font-size: 13px
-          color: $grey
-          display: block
-          float: left
-          text-align: center
-          font-weight: bold
-
-      .days
-        display: inline-block
-        width: 300px
-
-        .day
-          width: calc(300px / 7)
-          font-size: 13px
-          color: $grey
-          display: block
-          float: left
-          text-align: center
-          margin-bottom: 15px
-          cursor: pointer
-          font-weight: bold
-
-          &.is-within-range
-            background: $blue-light
-            color: $dark
-
-          &.is-from, &.is-first-weekday
-            border-top-left-radius: 50%
-            border-bottom-left-radius: 50%
-
-          &.is-to, &.is-last-weekday
-            border-top-right-radius: 50%
-            border-bottom-right-radius: 50%
-
-          .day-num
-            display: flex
-            justify-content: center
-            align-items: center
-            float: left
-            width: calc(300px / 7)
-            height: 100%
-            border-radius: 50%
-            padding: 10px 15px
-
-            &:hover, &.is-active
-              background: $blue
-              color: $white
-
-    .side-container
-      width: 158px
-      min-height: 390px
-      padding: 10px
-      display: flex
-      align-items: center
-      position: relative
-
-      .side-container-buttons
-        width: 138px
-
-        .side-button
-          background: $white
-          border-radius: 15px
-          border: 1px solid $blue
-          height: 30px
-          width: 138px
-          display: block
-          text-align: center
-          outline: none
-          margin-bottom: 15px
-          color: $text-button
-          font-size: 13px
-          cursor: pointer
-
-          &:hover, &.is-active
-            background: $blue
-            color: $white
-
-      .close-icon
-        position: absolute
-        width: 20px
-        height: 20px
-        top: 20px
-        right: 15px
-        cursor: pointer
-
   &.theme-green
     &.is-active
-      border-color: $cyan
+      border-color: $green
     .input-section
       .label-txt
-        color: $cyan
+        color: $green
       .cal-icon
         svg
           path
-            fill: $cyan
-    .calendar
-      border-color: $cyan
-      &:after
-        border-top-color: $cyan
-        border-left-color: $cyan
-      .calendar-container
-        .days
-          .day
-            &.is-within-range
-              background: lighten($cyan, 20)
-            .day-num
-              &:hover, &.is-active
-                background: $cyan
-      .side-container
-        .side-container-buttons
-          .side-button
-            border-color: $cyan
-            &:hover, &.is-active
-              background: $cyan
+            fill: $green
 
   &.theme-teal
     &.is-active
@@ -252,25 +81,6 @@
         svg
           path
             fill: $teal
-    .calendar
-      border-color: $teal
-      &:after
-        border-top-color: $teal
-        border-left-color: $teal
-      .calendar-container
-        .days
-          .day
-            &.is-within-range
-              background: lighten($teal, 20)
-            .day-num
-              &:hover, &.is-active
-                background: $teal
-      .side-container
-        .side-container-buttons
-          .side-button
-            border-color: $teal
-            &:hover, &.is-active
-              background: $teal
 
   &.theme-cyan
     &.is-active
@@ -282,25 +92,6 @@
         svg
           path
             fill: $cyan
-    .calendar
-      border-color: $cyan
-      &:after
-        border-top-color: $cyan
-        border-left-color: $cyan
-      .calendar-container
-        .days
-          .day
-            &.is-within-range
-              background: lighten($cyan, 20)
-            .day-num
-              &:hover, &.is-active
-                background: $cyan
-      .side-container
-        .side-container-buttons
-          .side-button
-            border-color: $cyan
-            &:hover, &.is-active
-              background: $cyan
 
   &.theme-grape
     &.is-active
@@ -312,25 +103,6 @@
         svg
           path
             fill: $grape
-    .calendar
-      border-color: $grape
-      &:after
-        border-top-color: $grape
-        border-left-color: $grape
-      .calendar-container
-        .days
-          .day
-            &.is-within-range
-              background: lighten($grape, 20)
-            .day-num
-              &:hover, &.is-active
-                background: $grape
-      .side-container
-        .side-container-buttons
-          .side-button
-            border-color: $grape
-            &:hover, &.is-active
-              background: $grape
 
   &.theme-red
     &.is-active
@@ -342,25 +114,6 @@
         svg
           path
             fill: $red
-    .calendar
-      border-color: $red
-      &:after
-        border-top-color: $red
-        border-left-color: $red
-      .calendar-container
-        .days
-          .day
-            &.is-within-range
-              background: lighten($red, 20)
-            .day-num
-              &:hover, &.is-active
-                background: $red
-      .side-container
-        .side-container-buttons
-          .side-button
-            border-color: $red
-            &:hover, &.is-active
-              background: $red
 
   &.theme-gray
     &.is-active
@@ -372,22 +125,4 @@
         svg
           path
             fill: $gray
-    .calendar
-      border-color: $gray
-      &:after
-        border-top-color: $gray
-        border-left-color: $gray
-      .calendar-container
-        .days
-          .day
-            &.is-within-range
-              background: lighten($gray, 20)
-            .day-num
-              &:hover, &.is-active
-                background: $gray
-      .side-container
-        .side-container-buttons
-          .side-button
-            border-color: $gray
-            &:hover, &.is-active
-              background: $gray
+  

--- a/src/ng-daterangepicker/shared/ng-daterangepicker-options.ts
+++ b/src/ng-daterangepicker/shared/ng-daterangepicker-options.ts
@@ -1,0 +1,10 @@
+export interface NgDateRangePickerOptions {
+  theme: 'default' | 'green' | 'teal' | 'cyan' | 'grape' | 'red' | 'gray';
+  range: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly';
+  dayNames: string[];
+  presetNames: string[];
+  dateFormat: string;
+  outputFormat: string;
+  startOfWeek: number;
+  container?: false | string;
+}

--- a/src/ng-daterangepicker/shared/ng-daterangerpicker.helper.ts
+++ b/src/ng-daterangepicker/shared/ng-daterangerpicker.helper.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+import { NgDateRangePickerOptions } from './ng-daterangepicker-options';
+import * as dateFns from 'date-fns';
+
+export interface DateObj {
+    dateFrom: Date;
+    dateTo: Date;
+}
+
+@Injectable()
+export class NgDateRangePickerHelper {
+
+    selectRange(options: NgDateRangePickerOptions, range?: 'tm' | 'lm' | 'lw' | 'tw' | 'ty' | 'ly'): DateObj {
+      let today = dateFns.startOfDay(new Date());
+      let dateFrom: Date;
+      let dateTo: Date;
+
+      switch (range || options.range) {
+      case 'tm':
+          dateFrom = dateFns.startOfMonth(today);
+          dateTo = dateFns.endOfMonth(today);
+          break;
+      case 'lm':
+          today = dateFns.subMonths(today, 1);
+          dateFrom = dateFns.startOfMonth(today);
+          dateTo = dateFns.endOfMonth(today);
+          break;
+      case 'lw':
+          today = dateFns.subWeeks(today, 1);
+          dateFrom = dateFns.startOfWeek(today, {weekStartsOn: options.startOfWeek});
+          dateTo = dateFns.endOfWeek(today, {weekStartsOn: options.startOfWeek});
+          break;
+      case 'tw':
+          dateFrom = dateFns.startOfWeek(today, {weekStartsOn: options.startOfWeek});
+          dateTo = dateFns.endOfWeek(today, {weekStartsOn: options.startOfWeek});
+          break;
+      case 'ty':
+          dateFrom = dateFns.startOfYear(today);
+          dateTo = dateFns.endOfYear(today);
+          break;
+      case 'ly':
+          today = dateFns.subYears(today, 1);
+          dateFrom = dateFns.startOfYear(today);
+          dateTo = dateFns.endOfYear(today);
+          break;
+      }
+
+      return {
+          dateFrom: dateFrom,
+          dateTo: dateTo
+      };
+  }
+
+}


### PR DESCRIPTION
To solve various overlapping display problems (parent containers with `overflow:hidden` for example), this PR allows the user to specify where the calendar popup should be attached too. See similar solution: http://valor-software.com/ngx-bootstrap/#/popover#container-body

New option:
`container?: false | string`
 
`false [default]` appends the calendar to the current position. Valid values include all valid `document.querySelector()` strings.

**Note:** This may be a bit akward to merge with other PRs: https://github.com/jkuri/ng-daterangepicker/pull/28 https://github.com/jkuri/ng-daterangepicker/pull/29 https://github.com/jkuri/ng-daterangepicker/pull/30
See: https://github.com/smasala/ng-daterangepicker/commit/dfa4ca287a128bbea2a699d789a27a1cd0a7b052 for full merge