### PR TITLE
fix defect of Sunday/1st day of a month issue

### DIFF
--- a/src/ng-daterangepicker/ng-daterangepicker.component.ts
+++ b/src/ng-daterangepicker/ng-daterangepicker.component.ts
@@ -122,7 +122,7 @@ export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit,
       };
     });
     
-    let prevMonthDayNum = dateFns.getDay(start)==0?6:dateFns.getDay(start) - 1;
+    let prevMonthDayNum = dateFns.getDay(start) == 0 ? 6 : dateFns.getDay(start) - 1;
     let prevMonthDays: IDay[] = [];
     if (prevMonthDayNum > 0) {
       prevMonthDays = Array.from(Array(prevMonthDayNum).keys()).map(i => {

--- a/src/ng-daterangepicker/ng-daterangepicker.component.ts
+++ b/src/ng-daterangepicker/ng-daterangepicker.component.ts
@@ -121,8 +121,8 @@ export class NgDateRangePickerComponent implements ControlValueAccessor, OnInit,
         isWithinRange: dateFns.isWithinRange(d, this.dateFrom, this.dateTo)
       };
     });
-
-    let prevMonthDayNum = dateFns.getDay(start) - 1;
+    
+    let prevMonthDayNum = dateFns.getDay(start)==0?6:dateFns.getDay(start) - 1;
     let prevMonthDays: IDay[] = [];
     if (prevMonthDayNum > 0) {
       prevMonthDays = Array.from(Array(prevMonthDayNum).keys()).map(i => {


### PR DESCRIPTION
As thoroughly detected, there seems to be a defect, happens when 1st also appears to be Sunday.

This commit is to modify the logic of adding prevMonthDay to every month's date set, and only one line has been changed.